### PR TITLE
Fix for a bug in seg_LabFusion when using -outProb

### DIFF
--- a/seg-lib/_seg_LabFusion.cpp
+++ b/seg-lib/_seg_LabFusion.cpp
@@ -1892,7 +1892,11 @@ nifti_image * seg_LabFusion::GetResult_probability()
             else
             {
                 long labelnumb = (int)this->FinalSeg[i];
-                Resultdata[i+labelnumb*Result->nx*Result->ny*Result->nz]=(int)this->FinalSeg[i]>1?1:(int)this->FinalSeg[i];
+                for(long currlabelnumb=0; currlabelnumb<this->NumberOfLabels; currlabelnumb++)
+                {
+                    Resultdata[i+currlabelnumb*Result->nx*Result->ny*Result->nz]= 0;
+                }
+                Resultdata[i+labelnumb*Result->nx*Result->ny*Result->nz]= 1;
             }
         }
 

--- a/seg-lib/_seg_LabFusion.cpp
+++ b/seg-lib/_seg_LabFusion.cpp
@@ -1891,7 +1891,8 @@ nifti_image * seg_LabFusion::GetResult_probability()
             }
             else
             {
-                Resultdata[i]=(int)this->FinalSeg[i]>1?1:(int)this->FinalSeg[i];
+                long labelnumb = (int)this->FinalSeg[i];
+                Resultdata[i+labelnumb*Result->nx*Result->ny*Result->nz]=(int)this->FinalSeg[i]>1?1:(int)this->FinalSeg[i];
             }
         }
 


### PR DESCRIPTION
There is a bug in seg_LabFusion when using -outProb.
The probabilities are not set correctly if one of the labels for this voxel has probability == 1.
Some of the code still originates from before multiple labels where supported.

Only checked for STEPS not for others.

(New pull request replacing #1 )