### PR TITLE
Seg tools library size limit

### DIFF
--- a/seg-apps/seg_LabFusion.cpp
+++ b/seg-apps/seg_LabFusion.cpp
@@ -465,6 +465,13 @@ int main(int argc, char **argv)
             Thresh_IMG_value=0.999;
         }
 
+	if(CLASSIFIER->nt > std::numeric_limits<libraryIndexType>::max())
+	{
+	  fprintf(stderr,"* Error: %s contains %d, more than the maximum supported\n",filename_LABELS, CLASSIFIER->nt);
+	    flush(cout);
+	    return 1;
+        }
+
         // *****************************
         //   CALCULATING REQUIRED SIZE
         // *****************************

--- a/seg-lib/_seg_LabFusion.h
+++ b/seg-lib/_seg_LabFusion.h
@@ -57,9 +57,9 @@ protected:
     float   Conv;
 
     // LNCC
-    unsigned char * LNCC;
+    libraryIndexType * LNCC;
     bool LNCC_status;
-    unsigned char * NCC;
+    libraryIndexType * NCC;
     bool NCC_status;
     int Numb_Neigh;
 

--- a/seg-lib/_seg_common.h
+++ b/seg-lib/_seg_common.h
@@ -89,6 +89,7 @@ inline int fabs(int _x)
 #include <new>
 #include <exception>
 #include <algorithm>
+#include <limits>
 #ifdef _OPENMP
 #include "omp.h"
 #endif

--- a/seg-lib/_seg_common.h
+++ b/seg-lib/_seg_common.h
@@ -98,6 +98,7 @@ inline int fabs(int _x)
 #define segPrecisionTYPE float
 /// @brief Defines the data type for categorical labels in seg_LabFusion.
 #define categoricalLabelType unsigned char
+#define libraryIndexType int
 
 /// @brief Defines the number of non-PV classes used in seg_LoAd. As seg_LoAd will be deprecated, this will also disapear.
 #define nonPVNumClass 5

--- a/seg-lib/_seg_tools.cpp
+++ b/seg-lib/_seg_tools.cpp
@@ -630,157 +630,62 @@ void SmoothLab(float * DataPTR,float factor, ImageSize * Currentsize){
 }
 
 
+
+
+int compareInt(const void *p1, const void *p2)
+{
+   if (*(int*)p1 <  *(int*)p2) return -1;
+   if (*(int*)p1 == *(int*)p2) return 0;
+   if (*(int*)p1 >  *(int*)p2) return 1;
+}
+
 int quickSort(int *arr, int elements)
 {
-
-    int  piv, beg[300], end[300], i=0, L, R, swap ;
-
-    beg[0]=0;
-    end[0]=elements;
-    while (i>=0)
-    {
-        L=beg[i];
-        R=end[i]-1;
-        if (L<R)
-        {
-            piv=arr[L];
-            while (L<R)
-            {
-                while (arr[R]>=piv && L<R) R--;
-                if (L<R) arr[L++]=arr[R];
-                while (arr[L]<=piv && L<R) L++;
-                if (L<R) arr[R--]=arr[L];
-            }
-            arr[L]=piv;
-            beg[i+1]=L+1;
-            end[i+1]=end[i];
-            end[i++]=L;
-            if (end[i]-beg[i]>end[i-1]-beg[i-1])
-            {
-                swap=beg[i];
-                beg[i]=beg[i-1];
-                beg[i-1]=swap;
-                swap=end[i];
-                end[i]=end[i-1];
-                end[i-1]=swap;
-            }
-        }
-        else
-        {
-            i--;
-        }
-    }
+    std::qsort(arr, elements, sizeof(int),compareInt);
+    return 1;
     return 1;
 }
 
 
+int compareFloat(const void *p1, const void *p2)
+{
+    if (*(float*)p1 <  *(float*)p2) return -1;
+    if (*(float*)p1 == *(float*)p2) return 0;
+    if (*(float*)p1 >  *(float*)p2) return 1;
+
+}
 int quickSort(float *arr, int elements)
 {
-
-    float  piv;
-    int beg[300], end[300], i=0, L, R, swap ;
-
-    beg[0]=0;
-    end[0]=elements;
-
-    while (i>=0)
-    {
-        L=beg[i];
-        R=end[i]-1;
-        if (L<R)
-        {
-            piv=arr[L];
-            while (L<R)
-            {
-                while (arr[R]>=piv && L<R) R--;
-                if (L<R) arr[L++]=arr[R];
-                while (arr[L]<=piv && L<R) L++;
-                if (L<R) arr[R--]=arr[L];
-            }
-            arr[L]=piv;
-            beg[i+1]=L+1;
-            end[i+1]=end[i];
-            end[i++]=L;
-            if (end[i]-beg[i]>end[i-1]-beg[i-1])
-            {
-                swap=beg[i];
-                beg[i]=beg[i-1];
-                beg[i-1]=swap;
-                swap=end[i];
-                end[i]=end[i-1];
-                end[i-1]=swap;
-            }
-        }
-        else
-        {
-            i--;
-        }
-    }
+    std::qsort(arr, elements, sizeof(float),compareFloat);
     return 1;
 }
 
 
+
+struct orderedFloatType {
+    int ind;
+    float val;
+};
+
+int compareOrderedFloatType(const void *p1, const void *p2)
+{
+  if (((orderedFloatType*)p1)->val <  ((orderedFloatType*)p2)->val) return -1;
+  if (((orderedFloatType*)p1)->val == ((orderedFloatType*)p2)->val) return 0;
+  if (((orderedFloatType*)p1)->val >  ((orderedFloatType*)p2)->val) return 1;
+}
 
 int * quickSort_order(float *arr, int elements)
 {
-
-    float  piv;
-    int piv_index, beg[300], end[300], i=0, L, R, swap ;
     int * order = new int [elements];
-    for(long index=0; index<elements; index++)
+    orderedFloatType orderedArr[elements];
+    for (int ind=0; ind<elements; ind++)
     {
-        order[index]=index;
+        orderedArr[ind].val=arr[ind];
+        orderedArr[ind].ind=ind;
     }
-    beg[0]=0;
-    end[0]=elements;
-    while (i>=0)
-    {
-        L=beg[i];
-        R=end[i]-1;
-        if (L<R)
-        {
-            piv=arr[L];
-            piv_index=order[L];
-            while (L<R)
-            {
-                while (arr[R]>=piv && L<R)
-                {
-                    R--;
-                }
-                if (L<R)
-                {
-                    arr[L]=arr[R];
-                    order[L++]=order[R];
-                }
-                while (arr[L]<=piv && L<R)
-                {
-                    L++;
-                }
-                if (L<R)
-                {
-                    arr[R]=arr[L];
-                    order[R--]=order[L];
-                }
-            }
-            arr[L]=piv;
-            order[L]=piv_index;
-            beg[i+1]=L+1;
-            end[i+1]=end[i];
-            end[i++]=L;
-            if (end[i]-beg[i]>end[i-1]-beg[i-1])
-            {
-                swap=beg[i];
-                beg[i]=beg[i-1];
-                beg[i-1]=swap;
-                swap=end[i];
-                end[i]=end[i-1];
-                end[i-1]=swap;
-            }
-        }
-        else
-        {
-            i--;
-        }
+    std::qsort(orderedArr, elements, sizeof(orderedFloatType),compareOrderedFloatType);
+    for (int ii=0; ii<elements; ii++){
+        order[ii]=orderedArr[ii].ind;
     }
     return order;
 }

--- a/seg-lib/_seg_tools.cpp
+++ b/seg-lib/_seg_tools.cpp
@@ -635,8 +635,8 @@ void SmoothLab(float * DataPTR,float factor, ImageSize * Currentsize){
 int compareInt(const void *p1, const void *p2)
 {
    if (*(int*)p1 <  *(int*)p2) return -1;
-   if (*(int*)p1 == *(int*)p2) return 0;
    if (*(int*)p1 >  *(int*)p2) return 1;
+   return 0;
 }
 
 int quickSort(int *arr, int elements)
@@ -650,9 +650,8 @@ int quickSort(int *arr, int elements)
 int compareFloat(const void *p1, const void *p2)
 {
     if (*(float*)p1 <  *(float*)p2) return -1;
-    if (*(float*)p1 == *(float*)p2) return 0;
     if (*(float*)p1 >  *(float*)p2) return 1;
-
+    return 0;
 }
 int quickSort(float *arr, int elements)
 {
@@ -670,8 +669,8 @@ struct orderedFloatType {
 int compareOrderedFloatType(const void *p1, const void *p2)
 {
   if (((orderedFloatType*)p1)->val <  ((orderedFloatType*)p2)->val) return -1;
-  if (((orderedFloatType*)p1)->val == ((orderedFloatType*)p2)->val) return 0;
   if (((orderedFloatType*)p1)->val >  ((orderedFloatType*)p2)->val) return 1;
+  return 0;
 }
 
 int * quickSort_order(float *arr, int elements)
@@ -736,7 +735,7 @@ void HeapSort(float * a,int n)
 
 
 
-unsigned char * estimateNCC4D(nifti_image * BaseImage,nifti_image * NCC,int numberordered,ImageSize * CurrSizes,int verbose)
+libraryIndexType * estimateNCC4D(nifti_image * BaseImage,nifti_image * NCC,int numberordered,ImageSize * CurrSizes,int verbose)
 {
 
     segPrecisionTYPE * NCCptr = static_cast<segPrecisionTYPE *>(NCC->data);
@@ -813,20 +812,20 @@ unsigned char * estimateNCC4D(nifti_image * BaseImage,nifti_image * NCC,int numb
     CurrSizes->numclass=realt;
 
 
-    unsigned char * NCC_ordered=new unsigned char [numberordered];
+    libraryIndexType * NCC_ordered=new libraryIndexType [numberordered];
 
     if (verbose>0)
     {
         cout << "Used Labels after sorting the GNCC"<<endl;
     }
 
-    int * ordertmp=quickSort_order(&NCCval[0],NCC->nt);
+    libraryIndexType * ordertmp=quickSort_order(&NCCval[0],NCC->nt);
     for(long lable_order=0; lable_order<numberordered; lable_order++)
     {
-        NCC_ordered[lable_order]=(char)ordertmp[NCC->nt-lable_order-1];
+        NCC_ordered[lable_order]=ordertmp[NCC->nt-lable_order-1];
         if (verbose>0)
         {
-            cout << (int)NCC_ordered[lable_order]+1 << "/" << numberordered<<endl;
+            cout << NCC_ordered[lable_order]+1 << "/" << numberordered<<endl;
         }
     }
 
@@ -1005,7 +1004,7 @@ float estimateNCC3D(nifti_image * BaseImage,nifti_image * Template,nifti_image *
 
 
 
-unsigned char * estimateROINCC4D(nifti_image * LableImage,nifti_image * BaseImage,nifti_image * NCC,int numberordered,ImageSize * CurrSizes,int DilSize, int verbose)
+libraryIndexType * estimateROINCC4D(nifti_image * LableImage,nifti_image * BaseImage,nifti_image * NCC,int numberordered,ImageSize * CurrSizes,int DilSize, int verbose)
 {
 
     segPrecisionTYPE * NCCptr = static_cast<segPrecisionTYPE *>(NCC->data);
@@ -1128,17 +1127,17 @@ unsigned char * estimateROINCC4D(nifti_image * LableImage,nifti_image * BaseImag
     CurrSizes->numclass=realt;
 
 
-    unsigned char * NCC_ordered=new unsigned char [numberordered];
+    libraryIndexType * NCC_ordered=new libraryIndexType [numberordered];
 
     if (verbose>0)
     {
         cout << "Used Labels after sorting the ROINCC"<<endl;
     }
 
-    int * ordertmp=quickSort_order(&NCCval[0],NCC->nt);
+    libraryIndexType * ordertmp=quickSort_order(&NCCval[0],NCC->nt);
     for(long lable_order=0; lable_order<numberordered; lable_order++)
     {
-        NCC_ordered[lable_order]=(char)ordertmp[NCC->nt-lable_order-1];
+        NCC_ordered[lable_order]=ordertmp[NCC->nt-lable_order-1];
         if (verbose>0)
         {
             cout << (int)NCC_ordered[lable_order]+1 << "/" << numberordered<<endl;
@@ -1150,13 +1149,13 @@ unsigned char * estimateROINCC4D(nifti_image * LableImage,nifti_image * BaseImag
 }
 
 
-unsigned char * estimateMLNCC4D(nifti_image * BaseImage, nifti_image * LNCC,float distance,int levels, int numberordered,ImageSize * CurrSizes,int verbose)
+libraryIndexType * estimateMLNCC4D(nifti_image * BaseImage, nifti_image * LNCC,float distance,int levels, int numberordered,ImageSize * CurrSizes,int verbose)
 {
 
     segPrecisionTYPE * LNCCptr = static_cast<segPrecisionTYPE *>(LNCC->data);
     segPrecisionTYPE * BaseImageptr = static_cast<segPrecisionTYPE *>(BaseImage->data);
-    unsigned char * LNCC_ordered=NULL;
-    unsigned char * LNCC_ordered_save=NULL;
+    libraryIndexType * LNCC_ordered=NULL;
+    libraryIndexType * LNCC_ordered_save=NULL;
 
 
     int numbordered_level_old=LNCC->nt;
@@ -1166,7 +1165,7 @@ unsigned char * estimateMLNCC4D(nifti_image * BaseImage, nifti_image * LNCC,floa
 
         if(curlevel==levels)
         {
-            LNCC_ordered_save=new unsigned char [numbordered_level_old*BaseImage->nx*BaseImage->ny*BaseImage->nz];
+            LNCC_ordered_save=new libraryIndexType [numbordered_level_old*BaseImage->nx*BaseImage->ny*BaseImage->nz];
             if(LNCC_ordered_save == NULL)
             {
                 fprintf(stderr,"* Error when alocating LNCC_ordered_save in function seg_norm4MLLNCC");
@@ -1288,7 +1287,7 @@ unsigned char * estimateMLNCC4D(nifti_image * BaseImage, nifti_image * LNCC,floa
         delete [] BaseMean;
 
         CurrSizes->tsize=realt;
-        LNCC_ordered=new unsigned char [numbordered_level*BaseImage->nx*BaseImage->ny*BaseImage->nz];
+        LNCC_ordered=new libraryIndexType [numbordered_level*BaseImage->nx*BaseImage->ny*BaseImage->nz];
         if(LNCC_ordered == NULL)
         {
             fprintf(stderr,"* Error when alocating LNCC_ordered in function seg_norm4LNCC");
@@ -1307,8 +1306,9 @@ unsigned char * estimateMLNCC4D(nifti_image * BaseImage, nifti_image * LNCC,floa
 #endif
         for(long i=0; i<LNCC->nx*LNCC->ny*LNCC->nz; i++)
         {
+	    // TODO: strip magic number 1000 here
             segPrecisionTYPE LNCCvalue_tmp[1000];
-            char old_sort[1000];;
+            libraryIndexType old_sort[1000];;
             for(long currlable=0; currlable<LNCC->nt; currlable++)
             {
                 LNCCvalue_tmp[currlable]=LNCCptr[i+currlable*LNCC->nx*LNCC->ny*LNCC->nz];
@@ -1319,12 +1319,12 @@ unsigned char * estimateMLNCC4D(nifti_image * BaseImage, nifti_image * LNCC,floa
                 old_sort[currlable]=LNCC_ordered_save[i+currlable*LNCC->nx*LNCC->ny*LNCC->nz];
             }
 
-            int * ordertmp=quickSort_order(&LNCCvalue_tmp[0],LNCC->nt);
+            libraryIndexType * ordertmp=quickSort_order(&LNCCvalue_tmp[0],LNCC->nt);
 
             int label_order_index=0;
             for(long lable_order=0; lable_order<LNCC->nt; lable_order++)
             {
-                char cur_LNCC_ordered_label=(char)ordertmp[LNCC->nt-lable_order-1];
+                libraryIndexType cur_LNCC_ordered_label=ordertmp[LNCC->nt-lable_order-1];
                 for(long currlable=0; currlable<numbordered_level_old; currlable++)
                 {
                     if(cur_LNCC_ordered_label==old_sort[currlable])
@@ -1348,7 +1348,7 @@ unsigned char * estimateMLNCC4D(nifti_image * BaseImage, nifti_image * LNCC,floa
         {
             numbordered_level_old=numbordered_level;
             delete [] LNCC_ordered_save;
-            LNCC_ordered_save=new unsigned char [numbordered_level_old*LNCC->nx*LNCC->ny*LNCC->nz];
+            LNCC_ordered_save=new libraryIndexType [numbordered_level_old*LNCC->nx*LNCC->ny*LNCC->nz];
             if(LNCC_ordered_save == NULL)
             {
                 fprintf(stderr,"* Error when alocating LNCC_ordered_save in function seg_norm4MLLNCC");
@@ -1573,12 +1573,12 @@ float seg_getNMIValue(nifti_image *img1,
 
 /* *************************************************************** */
 
-unsigned char * estimateLNCC5D(nifti_image * BaseImage, nifti_image * LNCC,float distance,int numberordered,ImageSize * CurrSizes,int verbose)
+libraryIndexType * estimateLNCC5D(nifti_image * BaseImage, nifti_image * LNCC,float distance,int numberordered,ImageSize * CurrSizes,int verbose)
 {
 
     segPrecisionTYPE * LNCCptr = static_cast<segPrecisionTYPE *>(LNCC->data);
     segPrecisionTYPE * BaseImageptr = static_cast<segPrecisionTYPE *>(BaseImage->data);
-    unsigned char * LNCC_ordered=NULL;
+    libraryIndexType * LNCC_ordered=NULL;
     long BaseImageXYZsize=BaseImage->nx*BaseImage->ny*BaseImage->nz;
     segPrecisionTYPE * BaseMean=new segPrecisionTYPE [BaseImageXYZsize*BaseImage->nt];
     if(BaseMean == NULL)
@@ -1702,7 +1702,7 @@ unsigned char * estimateLNCC5D(nifti_image * BaseImage, nifti_image * LNCC,float
     // cout << "Filtering LNCC"<< endl;
     //  Gaussian_Filter_4D(LNCCptr,(float)(distance),CurrSizes);
 
-    LNCC_ordered=new unsigned char [numberordered*BaseImage->nx*BaseImage->ny*BaseImage->nz];
+    LNCC_ordered=new libraryIndexType [numberordered*BaseImage->nx*BaseImage->ny*BaseImage->nz];
     if(LNCC_ordered == NULL)
     {
         fprintf(stderr,"* Error when alocating LNCC_ordered in function seg_norm4LNCC");
@@ -1728,11 +1728,11 @@ unsigned char * estimateLNCC5D(nifti_image * BaseImage, nifti_image * LNCC,float
             LNCCvalue_tmp[currlable]=LNCCptr[i+currlable*BaseImage->nx*BaseImage->ny*BaseImage->nz];
         }
 
-        int * ordertmp=quickSort_order(&LNCCvalue_tmp[0],LNCC->nt);
+        libraryIndexType * ordertmp=quickSort_order(&LNCCvalue_tmp[0],LNCC->nt);
 
         for(long lable_order=0; lable_order<numberordered; lable_order++)
         {
-            LNCC_ordered[i+lable_order*BaseImage->nx*BaseImage->ny*BaseImage->nz]=(unsigned char)ordertmp[LNCC->nt-lable_order-1];
+            LNCC_ordered[i+lable_order*BaseImage->nx*BaseImage->ny*BaseImage->nz]=ordertmp[LNCC->nt-lable_order-1];
         }
 
         delete [] ordertmp;
@@ -1748,12 +1748,12 @@ unsigned char * estimateLNCC5D(nifti_image * BaseImage, nifti_image * LNCC,float
 }
 /* *************************************************************** */
 
-unsigned char * estimateLNCC4D(nifti_image * BaseImage, nifti_image * LNCC,float distance,int numberordered,ImageSize * CurrSizes,int verbose)
+libraryIndexType * estimateLNCC4D(nifti_image * BaseImage, nifti_image * LNCC,float distance,int numberordered,ImageSize * CurrSizes,int verbose)
 {
 
     segPrecisionTYPE * LNCCptr = static_cast<segPrecisionTYPE *>(LNCC->data);
     segPrecisionTYPE * BaseImageptr = static_cast<segPrecisionTYPE *>(BaseImage->data);
-    unsigned char * LNCC_ordered=NULL;
+    libraryIndexType * LNCC_ordered=NULL;
     segPrecisionTYPE * BaseMean=new segPrecisionTYPE [BaseImage->nx*BaseImage->ny*BaseImage->nz];
     if(BaseMean == NULL)
     {
@@ -1863,7 +1863,7 @@ unsigned char * estimateLNCC4D(nifti_image * BaseImage, nifti_image * LNCC,float
     CurrSizes->tsize=realt;
     //  Gaussian_Filter_4D(LNCCptr,(float)(distance),CurrSizes);
 
-    LNCC_ordered=new unsigned char [numberordered*BaseImage->nx*BaseImage->ny*BaseImage->nz];
+    LNCC_ordered=new libraryIndexType [numberordered*BaseImage->nx*BaseImage->ny*BaseImage->nz];
     if(LNCC_ordered == NULL)
     {
         fprintf(stderr,"* Error when alocating LNCC_ordered in function seg_norm4LNCC");
@@ -1889,11 +1889,11 @@ unsigned char * estimateLNCC4D(nifti_image * BaseImage, nifti_image * LNCC,float
             LNCCvalue_tmp[currlable]=LNCCptr[i+currlable*BaseImage->nx*BaseImage->ny*BaseImage->nz];
         }
 
-        int * ordertmp=quickSort_order(&LNCCvalue_tmp[0],LNCC->nt);
+        libraryIndexType * ordertmp=quickSort_order(&LNCCvalue_tmp[0],LNCC->nt);
 
         for(long lable_order=0; lable_order<numberordered; lable_order++)
         {
-            LNCC_ordered[i+lable_order*BaseImage->nx*BaseImage->ny*BaseImage->nz]=(unsigned char)ordertmp[LNCC->nt-lable_order-1];
+            LNCC_ordered[i+lable_order*BaseImage->nx*BaseImage->ny*BaseImage->nz]=ordertmp[LNCC->nt-lable_order-1];
         }
 
         delete [] ordertmp;

--- a/seg-lib/_seg_tools.h
+++ b/seg-lib/_seg_tools.h
@@ -40,11 +40,11 @@ NIFTYSEG_WINEXPORT int * quickSort_order(float *arr, int elements);
 NIFTYSEG_WINEXPORT void HeapSort(float * a,int n);
 
 // Estimate the order of multiple types of NCC similarity (local, global, regional, multilevel) given the input target image and a 4D set of resampled images. To be used for label fusion.
-NIFTYSEG_WINEXPORT unsigned char * estimateNCC4D(nifti_image * BaseImage,nifti_image * NCC,int numberordered,ImageSize * CurrSizes,int verbose);
-NIFTYSEG_WINEXPORT unsigned char * estimateROINCC4D(nifti_image * LableImage,nifti_image * BaseImage,nifti_image * LNCC,int numberordered,ImageSize * CurrSizes,int DilSize, int verbose);
-NIFTYSEG_WINEXPORT unsigned char * estimateLNCC5D(nifti_image * BaseImage,nifti_image * LNCC,float distance,int numberordered,ImageSize * CurrSizes,int verbose);
-NIFTYSEG_WINEXPORT unsigned char * estimateLNCC4D(nifti_image * BaseImage,nifti_image * LNCC,float distance,int numberordered,ImageSize * CurrSizes,int verbose);
-NIFTYSEG_WINEXPORT unsigned char * estimateMLNCC4D(nifti_image * BaseImage, nifti_image * LNCC,float distance,int labels, int numberordered,ImageSize * CurrSizes,int verbose);
+NIFTYSEG_WINEXPORT libraryIndexType * estimateNCC4D(nifti_image * BaseImage,nifti_image * NCC,int numberordered,ImageSize * CurrSizes,int verbose);
+NIFTYSEG_WINEXPORT libraryIndexType * estimateROINCC4D(nifti_image * LableImage,nifti_image * BaseImage,nifti_image * LNCC,int numberordered,ImageSize * CurrSizes,int DilSize, int verbose);
+NIFTYSEG_WINEXPORT libraryIndexType * estimateLNCC5D(nifti_image * BaseImage,nifti_image * LNCC,float distance,int numberordered,ImageSize * CurrSizes,int verbose);
+NIFTYSEG_WINEXPORT libraryIndexType * estimateLNCC4D(nifti_image * BaseImage,nifti_image * LNCC,float distance,int numberordered,ImageSize * CurrSizes,int verbose);
+NIFTYSEG_WINEXPORT libraryIndexType * estimateMLNCC4D(nifti_image * BaseImage, nifti_image * LNCC,float distance,int labels, int numberordered,ImageSize * CurrSizes,int verbose);
 NIFTYSEG_WINEXPORT float estimateNCC3D(nifti_image * BaseImage,nifti_image * Template,nifti_image * Mask,int verbose);
 NIFTYSEG_WINEXPORT float seg_getNMIValue(nifti_image *referenceImage, nifti_image *warpedImage, unsigned char *referenceMask);
 


### PR DESCRIPTION
Fixes#10 by adding a specific type for the library index, which is increased to int and an error in the unlikely event the new limit is ever exceeded. Replaces the custom order-returning quicksort with an approach based on standard qsort, there is a very small performance hit, but it is negligible and it is easier to be certain it will work with the increased template size. (It may also be replaced by another standard sort if required.)