### PR TITLE
Seg tools template qsort

### DIFF
--- a/seg-lib/_seg_tools.cpp
+++ b/seg-lib/_seg_tools.cpp
@@ -632,62 +632,6 @@ void SmoothLab(float * DataPTR,float factor, ImageSize * Currentsize){
 
 
 
-int compareInt(const void *p1, const void *p2)
-{
-   if (*(int*)p1 <  *(int*)p2) return -1;
-   if (*(int*)p1 >  *(int*)p2) return 1;
-   return 0;
-}
-
-int quickSort(int *arr, int elements)
-{
-    std::qsort(arr, elements, sizeof(int),compareInt);
-    return 1;
-    return 1;
-}
-
-
-int compareFloat(const void *p1, const void *p2)
-{
-    if (*(float*)p1 <  *(float*)p2) return -1;
-    if (*(float*)p1 >  *(float*)p2) return 1;
-    return 0;
-}
-int quickSort(float *arr, int elements)
-{
-    std::qsort(arr, elements, sizeof(float),compareFloat);
-    return 1;
-}
-
-
-
-struct orderedFloatType {
-    int ind;
-    float val;
-};
-
-int compareOrderedFloatType(const void *p1, const void *p2)
-{
-  if (((orderedFloatType*)p1)->val <  ((orderedFloatType*)p2)->val) return -1;
-  if (((orderedFloatType*)p1)->val >  ((orderedFloatType*)p2)->val) return 1;
-  return 0;
-}
-
-int * quickSort_order(float *arr, int elements)
-{
-    int * order = new int [elements];
-    orderedFloatType orderedArr[elements];
-    for (int ind=0; ind<elements; ind++)
-    {
-        orderedArr[ind].val=arr[ind];
-        orderedArr[ind].ind=ind;
-    }
-    std::qsort(orderedArr, elements, sizeof(orderedFloatType),compareOrderedFloatType);
-    for (int ii=0; ii<elements; ii++){
-        order[ii]=orderedArr[ii].ind;
-    }
-    return order;
-}
 
 
 

--- a/seg-lib/_seg_tools.h
+++ b/seg-lib/_seg_tools.h
@@ -33,10 +33,8 @@ template <class NewTYPE> NIFTYSEG_WINEXPORT
 //template NIFTYSEG_WINEXPORT int seg_changeDatatype<double>(nifti_image *);
 
 // Sorting algrithms (with and without providing the order), for different data types
-NIFTYSEG_WINEXPORT int quickSort(int *arr, int elements);
-NIFTYSEG_WINEXPORT int quickSort(float *arr, int elements);
-NIFTYSEG_WINEXPORT int * quickSort_order(int *arr, int elements);
-NIFTYSEG_WINEXPORT int * quickSort_order(float *arr, int elements);
+NIFTYSEG_WINEXPORT template<class compType> int quickSort(compType *arr, int elements);
+NIFTYSEG_WINEXPORT template<class compType> int * quickSort_order(compType *arr, int elements);
 NIFTYSEG_WINEXPORT void HeapSort(float * a,int n);
 
 // Estimate the order of multiple types of NCC similarity (local, global, regional, multilevel) given the input target image and a 4D set of resampled images. To be used for label fusion.
@@ -83,3 +81,52 @@ NIFTYSEG_WINEXPORT void otsu(float * Image, int * mask, ImageSize *Currentsize )
 
 template <class DTYPE> NIFTYSEG_WINEXPORT void seg_mat44_mul(mat44 const* mat, DTYPE const* in,DTYPE *out);
 
+template <class compType>
+int quickSortComp(const void *p1, const void *p2)
+{
+   if (*(compType*)p1 <  *(compType*)p2) return -1;
+   if (*(compType*)p1 >  *(compType*)p2) return 1;
+   return 0;
+}
+
+template <class compType>
+int quickSort(compType *arr, int elements)
+{
+    std::qsort(arr, elements, sizeof(compType),quickSortComp<compType>);
+    return 1;
+}
+
+
+template <class compType>
+struct orderedType {
+    // Probably we should make it a class and just overload <,>
+    int ind;
+    compType val;
+};
+
+template <class compType>
+int compareOrderedType(const void *p1, const void *p2)
+{
+    if (((compType*)p1)->val <  ((compType*)p2)->val) return -1;
+    if (((compType*)p1)->val >  ((compType*)p2)->val) return 1;
+    return 0;
+}
+
+template <class compType>
+int * quickSort_order(compType *arr, int elements)
+{
+    typedef orderedType<compType> ourType;
+    int * order = new int [elements];
+    ourType orderedArr[elements];
+    for (int ind=0; ind<elements; ind++)
+    {
+        orderedArr[ind].val=arr[ind];
+        orderedArr[ind].ind=ind;
+    }
+    std::qsort(orderedArr, elements, sizeof(ourType),
+	       compareOrderedType<ourType>);
+    for (int ii=0; ii<elements; ii++){
+        order[ii]=orderedArr[ii].ind;
+    }
+    return order;
+}

--- a/seg-lib/_seg_tools.h
+++ b/seg-lib/_seg_tools.h
@@ -99,18 +99,22 @@ int quickSort(compType *arr, int elements)
 
 template <class compType>
 struct orderedType {
-    // Probably we should make it a class and just overload <,>
     int ind;
     compType val;
+    typedef orderedType<compType> thisType;
+    friend bool operator<(const thisType& l, const thisType& r)
+    {
+        return l.val < r.val;
+    }
+    friend bool operator>(const thisType& l, const thisType& r)
+    {
+        return l.val > r.val;
+    }
+    friend bool operator==(const thisType& l, const thisType& r)
+    {
+        return l.val == r.val;
+    }
 };
-
-template <class compType>
-int compareOrderedType(const void *p1, const void *p2)
-{
-    if (((compType*)p1)->val <  ((compType*)p2)->val) return -1;
-    if (((compType*)p1)->val >  ((compType*)p2)->val) return 1;
-    return 0;
-}
 
 template <class compType>
 int * quickSort_order(compType *arr, int elements)
@@ -124,7 +128,7 @@ int * quickSort_order(compType *arr, int elements)
         orderedArr[ind].ind=ind;
     }
     std::qsort(orderedArr, elements, sizeof(ourType),
-	       compareOrderedType<ourType>);
+	       quickSortComp<ourType>);
     for (int ii=0; ii<elements; ii++){
         order[ii]=orderedArr[ii].ind;
     }


### PR DESCRIPTION
This is an additional pull request (last one for the moment) to the one addressing the template library size limit, it's sort of a code cleanup in that it makes the qsort related functions templates so they do not need to be redefined for every type. However it doesn't make the code much smaller and places templates in .h, so you may not want to accept, but I thought I'd place the pull request for completeness.

Thanks for merging the others, hope all is well with you.